### PR TITLE
[React Native] Guard against unavailable captureStackTrace

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -7,7 +7,9 @@ class ApiError extends Error {
     this.response = response;
     this.json = json;
 
-    Error.captureStackTrace(this, ApiError);
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ApiError);
+    }
   }
 
   isHeaderPresent(key) {


### PR DESCRIPTION
fixes this error for react native apps:
![screen shot 2018-03-16 at 11 10 24 pm](https://user-images.githubusercontent.com/158675/37551080-41713c34-296f-11e8-933b-795bbc7d7c6a.png)


see related https://github.com/auth0/react-native-auth0/pull/33

