### PR TITLE
onResponse callback

### DIFF
--- a/src/api-request.js
+++ b/src/api-request.js
@@ -72,6 +72,9 @@ class ApiRequest {
         // Fail silently if response body is not present or malformed JSON:
         apiResponse.json = null;
       }).then(() => {
+        if (this.client.onResponse) {
+          this.client.onResponse(apiResponse);
+        }
         if (!response.ok) {
           throw new ApiError(apiResponse);
         }

--- a/src/api-request.js
+++ b/src/api-request.js
@@ -41,7 +41,7 @@ class ApiRequest {
       headers: newHeaders,
       method,
       body: newBody,
-    }).then(this._handleResponse);
+    }).then(this._handleResponse.bind(this));
   }
 
   urlFor(path) {

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ const constants = require('./constants');
 
 class Wealthsimple {
   constructor({
-    clientId, clientSecret, auth, fetchAdapter, env = null, baseUrl = null, apiVersion = 'v1', onAuthSuccess = null, onAuthRevoke = null, verbose = false,
+    clientId, clientSecret, auth, fetchAdapter, env = null, baseUrl = null, apiVersion = 'v1', onAuthSuccess = null, onAuthRevoke = null, onResponse = null, verbose = false,
   }) {
     // OAuth client details:
     if (!clientId || typeof clientId !== 'string') {
@@ -59,6 +59,7 @@ class Wealthsimple {
     // Optionally allow for callbacks on certain key events:
     this.onAuthSuccess = onAuthSuccess;
     this.onAuthRevoke = onAuthRevoke;
+    this.onResponse = onResponse;
 
     this.request = new ApiRequest({ client: this });
   }


### PR DESCRIPTION
internally, this callback will let mimic angular `$http` https://github.com/angular/angular.js/blob/45879a8c5a2222f88bcd1c0fcc0acabbddb1693f/src/ng/http.js#L353
by letting us call $rootScope.$applyAsync when responses are received.

This removes the need for code like this: https://github.com/wealthsimple/terminal/blob/29d75963686e20c2e047d4bd122ec5ea647b3ee9/src/app/common/components/login-wizard/login-wizard.controller.js#L99...L102