### PR TITLE
Handle claim OTP header

### DIFF
--- a/src/api-response.js
+++ b/src/api-response.js
@@ -51,6 +51,14 @@ class ApiResponse {
     return otp;
   }
 
+  getOTPClaim() {
+    const otpClaimString = this.headers.get(constants.OTP_CLAIM_HEADER);
+    if (!otpClaimString) {
+      return null;
+    }
+    return otpClaimString;
+  }
+
   toString() {
     let message = `Response status: ${this.status}`;
     try {

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,4 +2,5 @@ module.exports = {
   API_VERSIONS: ['v1'],
   ENVIRONMENTS: ['development', 'sandbox', 'production'],
   OTP_HEADER: 'x-wealthsimple-otp',
+  CLAIM_OTP_HEADER: 'x-wealthsimple-claim-otp',
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,5 +2,5 @@ module.exports = {
   API_VERSIONS: ['v1'],
   ENVIRONMENTS: ['development', 'sandbox', 'production'],
   OTP_HEADER: 'x-wealthsimple-otp',
-  CLAIM_OTP_HEADER: 'x-wealthsimple-claim-otp',
+  OTP_CLAIM_HEADER: 'x-wealthsimple-otp-claim',
 };

--- a/src/index.js
+++ b/src/index.js
@@ -96,9 +96,9 @@ class Wealthsimple {
       delete attributes.otp;
     }
 
-    if (attributes.claim_otp) {
-      headers[constants.CLAIM_OTP_HEADER] = attributes.claim_otp;
-      delete attributes.claim_otp;
+    if (attributes.otp_claim) {
+      headers[constants.OTP_CLAIM_HEADER] = attributes.otp_claim;
+      delete attributes.otp_claim;
     }
 
     let checkAuthRefresh = true;

--- a/src/index.js
+++ b/src/index.js
@@ -96,6 +96,11 @@ class Wealthsimple {
       delete attributes.otp;
     }
 
+    if (attributes.claim_otp) {
+      headers[constants.CLAIM_OTP_HEADER] = attributes.claim_otp;
+      delete attributes.claim_otp;
+    }
+
     let checkAuthRefresh = true;
     if (attributes.hasOwnProperty('checkAuthRefresh')) {
       ({ checkAuthRefresh } = attributes);

--- a/src/index.js
+++ b/src/index.js
@@ -96,9 +96,9 @@ class Wealthsimple {
       delete attributes.otp;
     }
 
-    if (attributes.otp_claim) {
-      headers[constants.OTP_CLAIM_HEADER] = attributes.otp_claim;
-      delete attributes.otp_claim;
+    if (attributes.otpClaim) {
+      headers[constants.OTP_CLAIM_HEADER] = attributes.otpClaim;
+      delete attributes.otpClaim;
     }
 
     let checkAuthRefresh = true;


### PR DESCRIPTION
Add support for the `x-wealthsimple-claim-otp` header, used for remembering 2fa.