### PR TITLE
Ignore dev dependencies for RetireJs

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "lint": "eslint '**/*.js'",
-    "retire": "retire --ignore dist",
+    "retire": "retire --ignore dist -n -p",
     "test": "jest --watch",
     "test:all": "yarn retire && yarn lint && jest --runInBand",
     "prebuild": "rm -rf dist",


### PR DESCRIPTION
Retirejs fails build b/c a dev dependency (jest) uses stringstream@0.0.5. Source: https://hackerone.com/reports/321670

Jest has not fixed their dependency yet in their latest build.

We can ignore dev dependencies from being included in retirejs check. Source: https://github.com/RetireJS/retire.js/issues/71