### PR TITLE
Prefer access tokens to bootstrap auth context, expose onAuthInvalid callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ See [samples directory](./samples) for a wide range of samples, or see the basic
 ```js
 const Wealthsimple = require('wealthsimple');
 
-const wealthsimple = new Wealthsimple({
+const wealthsimple = await new Wealthsimple({
   env: 'sandbox',
   clientId: '<oauth_client_id>',
 
@@ -33,12 +33,14 @@ const wealthsimple = new Wealthsimple({
 
   // Optional: If available, you can optionally specify a previous auth
   // response's access token so that the user does not have to login again:
+  //
+  // NOTE: Makes constructor return a promise!
   authAccessToken: '<your_current_access_token>',
 
   // (Deprecated) Optional: If available, you can optionally specify a previous
   // auth response so that the user does not have to login again:
   auth: { ... previous auth response ... },
-});
+}).then((wealthsimple) => { console.log('Previous access token is valid and client is ready'); return wealthsimple; }); // .then() only needed if `authAccessToken` is set
 
 wealthsimple.get('/healthcheck')
   .then(data => console.log(data));

--- a/README.md
+++ b/README.md
@@ -31,9 +31,13 @@ const wealthsimple = new Wealthsimple({
   // Optional: Depending on grant_type may or may not be needed:
   clientSecret: '<oauth_client_secret>',
 
-  // Optional: If available, you can optionally specify a previous auth response
-  // so that the user does not have to login again:
-  auth: { ...prior server response... },
+  // Optional: If available, you can optionally specify a previous auth
+  // response's access token so that the user does not have to login again:
+  authAccessToken: '<your_current_access_token>',
+
+  // (Deprecated) Optional: If available, you can optionally specify a previous
+  // auth response so that the user does not have to login again:
+  auth: { ... previous auth response ... },
 });
 
 wealthsimple.get('/healthcheck')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthsimple/wealthsimple",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A JavaScript client for the Wealthsimple API",
   "license": "MIT",
   "main": "dist/wealthsimple.min.js",

--- a/samples/2fa.js
+++ b/samples/2fa.js
@@ -33,6 +33,9 @@ const handleOtp = () => {
 };
 
 authPromise
+  .then((resp) => {
+    console.error('No OTP/2FA required!', resp.json);
+  })
   .catch((error) => {
     const otp = error.response.getOTP();
     console.log('OTP? ', otp);

--- a/samples/auth.js
+++ b/samples/auth.js
@@ -27,6 +27,8 @@ const authPromise = wealthsimple.authenticate({
 authPromise
   .then(() => {
     console.log('Client ID:', wealthsimple.clientCanonicalId());
+    console.log('Access token:', wealthsimple.accessToken());
+    console.log('Refresh token:', wealthsimple.refreshToken());
     return wealthsimple.get(`/users/${wealthsimple.resourceOwnerId()}`);
   })
   .then(response => console.log('Success: ', response.json))

--- a/samples/callbacks.js
+++ b/samples/callbacks.js
@@ -6,6 +6,7 @@ const wealthsimple = new Wealthsimple({
   clientId: '58a99e4862a1b246a7745523ca230e61dd7feff351056fcb22c73a5d7a2fcd69',
   onAuthSuccess: (data) => { console.log('success!', data); },
   onAuthRevoke: () => { console.log('revoked!'); },
+  onAuthInvalid: () => { console.log('invalid/unauthorized!'); },
 });
 
 const authPromise = wealthsimple.authenticate({
@@ -17,5 +18,12 @@ const authPromise = wealthsimple.authenticate({
 
 // Revoke auth after successful authentication:
 authPromise
-  .then(() => { wealthsimple.revokeAuth(); })
-  .catch(error => console.error('Error:', error));
+  .then(() => wealthsimple.revokeAuth())
+  .catch(error => console.error('Error:', error))
+  .finally(() => {
+    console.info('Should be an invalid call:')
+    // Make the auth invalid callback fire
+    return wealthsimple.get('/oauth/token/info')
+      .then(response => console.error('should never reach this point', response))
+      .catch(apiError => console.info('Sample ApiError: ', apiError.message));
+  });

--- a/samples/callbacks.js
+++ b/samples/callbacks.js
@@ -21,7 +21,7 @@ authPromise
   .then(() => wealthsimple.revokeAuth())
   .catch(error => console.error('Error:', error))
   .finally(() => {
-    console.info('Should be an invalid call:')
+    console.info('Should be an invalid call:');
     // Make the auth invalid callback fire
     return wealthsimple.get('/oauth/token/info')
       .then(response => console.error('should never reach this point', response))

--- a/samples/existing_access_token.js
+++ b/samples/existing_access_token.js
@@ -1,0 +1,51 @@
+// This example shows how to get authenticated user data.
+// You must set EMAIL + PASSWORD in `.env` corresponding to a valid staging user.
+
+require('dotenv').config();
+const Wealthsimple = require('../src/index');
+
+const previousWealthsimple = new Wealthsimple({
+  env: 'sandbox',
+  clientId: '58a99e4862a1b246a7745523ca230e61dd7feff351056fcb22c73a5d7a2fcd69',
+  // If available, you can optionally specify a previous auth response so that
+  // the user does not have to login again:
+  // auth: { ...prior server response... }
+});
+
+previousWealthsimple.get('/healthcheck')
+  .then(response => console.log(response.json));
+
+const authPromise = previousWealthsimple.authenticate({
+  grantType: 'password',
+  scope: 'read write',
+  username: process.env.EMAIL,
+  password: process.env.PASSWORD,
+});
+
+let existingAccessToken;
+
+authPromise
+  .then(() => existingAccessToken = previousWealthsimple.accessToken())
+  .catch(error => console.error('Error:', error))
+  .then(async () => {
+    const wealthsimple = await new Wealthsimple({
+      env: 'sandbox',
+      clientId: '58a99e4862a1b246a7745523ca230e61dd7feff351056fcb22c73a5d7a2fcd69',
+      authAccessToken: existingAccessToken
+    }).then((wealthsimple) => {
+      debugger;
+      console.log('Verified previous access token!', wealthsimple.accessToken())
+      console.log('Refresh:', wealthsimple.refreshToken())
+      return wealthsimple;
+    });
+  });
+
+const badWealthsimple = new Wealthsimple({
+  env: 'sandbox',
+  clientId: '58a99e4862a1b246a7745523ca230e61dd7feff351056fcb22c73a5d7a2fcd69',
+  authAccessToken: 'd7feff351056fcb22c73a5d7a2fcd6958a99e4862a1b246a7745523ca230e61d'
+}).then((wealthsimple) => {
+  console.log('Previous access token didn\'t work! Ignored:', wealthsimple.accessToken())
+  console.log('Refresh should be empty:', wealthsimple.refreshToken())
+  return wealthsimple;
+});

--- a/samples/existing_access_token.js
+++ b/samples/existing_access_token.js
@@ -25,27 +25,28 @@ const authPromise = previousWealthsimple.authenticate({
 let existingAccessToken;
 
 authPromise
-  .then(() => existingAccessToken = previousWealthsimple.accessToken())
+  .then(() => { existingAccessToken = previousWealthsimple.accessToken(); })
   .catch(error => console.error('Error:', error))
   .then(async () => {
     const wealthsimple = await new Wealthsimple({
       env: 'sandbox',
       clientId: '58a99e4862a1b246a7745523ca230e61dd7feff351056fcb22c73a5d7a2fcd69',
-      authAccessToken: existingAccessToken
-    }).then((wealthsimple) => {
-      debugger;
-      console.log('Verified previous access token!', wealthsimple.accessToken())
-      console.log('Refresh:', wealthsimple.refreshToken())
-      return wealthsimple;
+      authAccessToken: existingAccessToken,
+    }).then((wsClient) => {
+      console.log('Verified previous access token!', wsClient.accessToken());
+      console.log('Refresh:', wsClient.refreshToken());
+      return wsClient;
     });
+    console.log(wealthsimple);
   });
 
-const badWealthsimple = new Wealthsimple({
+new Wealthsimple({
   env: 'sandbox',
   clientId: '58a99e4862a1b246a7745523ca230e61dd7feff351056fcb22c73a5d7a2fcd69',
-  authAccessToken: 'd7feff351056fcb22c73a5d7a2fcd6958a99e4862a1b246a7745523ca230e61d'
+  authAccessToken: 'd7feff351056fcb22c73a5d7a2fcd6958a99e4862a1b246a7745523ca230e61d',
 }).then((wealthsimple) => {
-  console.log('Previous access token didn\'t work! Ignored:', wealthsimple.accessToken())
-  console.log('Refresh should be empty:', wealthsimple.refreshToken())
+  console.log('Previous access token didn\'t work! Ignored:', wealthsimple.accessToken());
+  console.log('Refresh should be empty:', wealthsimple.refreshToken());
+  console.log(wealthsimple);
   return wealthsimple;
 });

--- a/src/index.js
+++ b/src/index.js
@@ -77,9 +77,8 @@ class Wealthsimple {
           }
           throw new ApiError(error.response);
         });
-    } else {
-      this.auth = auth;
     }
+    this.auth = auth;
   }
 
   accessToken() {

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ const constants = require('./constants');
 
 class Wealthsimple {
   constructor({
-    clientId, clientSecret, authOrAccessToken, fetchAdapter, env = null, baseUrl = null, apiVersion = 'v1', onAuthSuccess = null, onAuthRevoke = null, onAuthInvalid = null, onResponse = null, verbose = false,
+    clientId, clientSecret, fetchAdapter, auth = null, authAccessToken = null, env = null, baseUrl = null, apiVersion = 'v1', onAuthSuccess = null, onAuthRevoke = null, onAuthInvalid = null, onResponse = null, verbose = false,
   }) {
     // OAuth client details:
     if (!clientId || typeof clientId !== 'string') {
@@ -63,8 +63,8 @@ class Wealthsimple {
     // Optionally pass in existing OAuth details (access_token + refresh_token)
     // or just the access token (then fetching the details) so that the user
     // does not have to be prompted to log in again:
-    if (authOrAccessToken && typeof authOrAccessToken === 'string') {
-      this.get('/oauth/token/info', { headers: { Authorization: `Bearer ${authOrAccessToken}` }, checkAuthRefresh: false })
+    if (authAccessToken && typeof authAccessToken === 'string') {
+      this.get('/oauth/token/info', { headers: { Authorization: `Bearer ${authAccessToken}` }, checkAuthRefresh: false })
         .then((response) => {
           this.auth = response.json.token; // the info endpoint nests auth in a `token` root key
           return response;
@@ -78,7 +78,7 @@ class Wealthsimple {
           throw new ApiError(error.response);
         });
     } else {
-      this.auth = authOrAccessToken;
+      this.auth = auth;
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -184,7 +184,7 @@ class Wealthsimple {
     body = null,
     checkAuthRefresh = true,
   }) {
-    const exeturePrimaryRequest = () => {
+    const executePrimaryRequest = () => {
       if (!this.isAuthExpired() && this.auth) {
         headers.Authorization = `Bearer ${this.auth.access_token}`;
       }
@@ -196,9 +196,9 @@ class Wealthsimple {
     if (checkAuthRefresh && this.isAuthRefreshable() && this.isAuthExpired()) {
       // Automatically refresh auth using refresh_token, then subsequently
       // perform the actual request:
-      return this.refreshAuth().then(exeturePrimaryRequest);
+      return this.refreshAuth().then(executePrimaryRequest);
     }
-    return exeturePrimaryRequest().catch((error) => {
+    return executePrimaryRequest().catch((error) => {
       if (error.response.status === 401 && this.onAuthInvalid) {
         this.onAuthInvalid(error.response.json);
       }

--- a/src/index.js
+++ b/src/index.js
@@ -64,22 +64,31 @@ class Wealthsimple {
     // or just the access token (then fetching the details) so that the user
     // does not have to be prompted to log in again:
     if (authAccessToken && typeof authAccessToken === 'string') {
-      this.get('/oauth/token/info', { headers: { Authorization: `Bearer ${authAccessToken}` }, checkAuthRefresh: false })
+      return this.get('/oauth/token/info', { headers: { Authorization: `Bearer ${authAccessToken}` }, checkAuthRefresh: false })
         .then((response) => {
           this.auth = response.json.token; // the info endpoint nests auth in a `token` root key
-          return response;
+          return this;
         }).catch((error) => {
           if (error.response.status === 401) {
             if (this.onAuthInvalid) {
               this.onAuthInvalid(error.response.json);
             }
-            return;
+            return this;
           }
           throw new ApiError(error.response);
         });
     } else {
       this.auth = auth;
     }
+  }
+
+  accessToken() {
+    // info endpoint and POST response have different structures
+    return this.auth && (this.auth.access_token || this.auth.token);
+  }
+
+  refreshToken() {
+    return this.auth && this.auth.refresh_token;
   }
 
   resourceOwnerId() {


### PR DESCRIPTION
This will be used so Terminal only has to store an access token in a session cookie vs the refresh token. Benefits from hard reloads forcing a "let's get the facts" from the authorization server.

onAuthInvalid callback allows cleanup when its apparent the token is expired, missing, malformed, or revoked.