### PR TITLE
Abstract Promise in constructor, block HTTP calls until its finished

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ See [samples directory](./samples) for a wide range of samples, or see the basic
 ```js
 const Wealthsimple = require('wealthsimple');
 
-const wealthsimple = await new Wealthsimple({
+const wealthsimple = new Wealthsimple({
   env: 'sandbox',
   clientId: '<oauth_client_id>',
 
@@ -33,14 +33,12 @@ const wealthsimple = await new Wealthsimple({
 
   // Optional: If available, you can optionally specify a previous auth
   // response's access token so that the user does not have to login again:
-  //
-  // NOTE: Makes constructor return a promise!
   authAccessToken: '<your_current_access_token>',
 
   // (Deprecated) Optional: If available, you can optionally specify a previous
   // auth response so that the user does not have to login again:
   auth: { ... previous auth response ... },
-}).then((wealthsimple) => { console.log('Previous access token is valid and client is ready'); return wealthsimple; }); // .then() only needed if `authAccessToken` is set
+});
 
 wealthsimple.get('/healthcheck')
   .then(data => console.log(data));
@@ -65,6 +63,27 @@ authPromise
 
 authPromise
   .then(() => wealthsimple.get('/deposits', { query: { limit: 2, sort_by: 'amount', sort_order: 'desc' } }))
+  .then(data => console.log('Success: ', data))
+  .catch(error => console.error('Error:', error));
+```
+
+Loading previously saved token for authenicated requests:
+
+```js
+const accessTokenCookie = document.cookie
+  .split(';')
+  .map((e) => e.split('='))
+  .find((e) =>  e[0] == '_accessToken' )[1];
+
+// Constructor async bootsraps auth context
+const wealthsimple = new Wealthsimple({
+  env: 'sandbox',
+  clientId: '<oauth_client_id>',
+  authAccessToken: accessTokenCookie,
+});
+
+// Will wait until auth context is loaded
+wealthsimple.get(`/users/${wealthsimple.resourceOwnerId()}`))
   .then(data => console.log('Success: ', data))
   .catch(error => console.error('Error:', error));
 ```

--- a/samples/existing_access_token.js
+++ b/samples/existing_access_token.js
@@ -27,26 +27,36 @@ let existingAccessToken;
 authPromise
   .then(() => { existingAccessToken = previousWealthsimple.accessToken(); })
   .catch(error => console.error('Error:', error))
-  .then(async () => {
-    const wealthsimple = await new Wealthsimple({
+  .then(() => {
+    const wealthsimple = new Wealthsimple({
       env: 'sandbox',
       clientId: '58a99e4862a1b246a7745523ca230e61dd7feff351056fcb22c73a5d7a2fcd69',
       authAccessToken: existingAccessToken,
-    }).then((wsClient) => {
-      console.log('Verified previous access token!', wsClient.accessToken());
-      console.log('Refresh:', wsClient.refreshToken());
-      return wsClient;
     });
-    console.log(wealthsimple);
+    console.log(existingAccessToken);
+    console.log('Chances are Wealthsimple.auth is null:', wealthsimple.auth);
+    console.log('Chances are Wealthsimple.authPromise is pending:', wealthsimple.authPromise);
+    wealthsimple.get('/users').then(() => {
+      console.log('Wealthsimple.authPromise is resolved by now', wealthsimple.authPromise);
+      console.log('Wealthsimple.auth is set by now', wealthsimple.auth);
+      console.log('Verified previous access token!', wealthsimple.accessToken());
+      console.log('Refresh:', wealthsimple.refreshToken());
+    });
   });
 
-new Wealthsimple({
+const badWealthsimple = new Wealthsimple({
   env: 'sandbox',
   clientId: '58a99e4862a1b246a7745523ca230e61dd7feff351056fcb22c73a5d7a2fcd69',
   authAccessToken: 'd7feff351056fcb22c73a5d7a2fcd6958a99e4862a1b246a7745523ca230e61d',
-}).then((wealthsimple) => {
-  console.log('Previous access token didn\'t work! Ignored:', wealthsimple.accessToken());
-  console.log('Refresh should be empty:', wealthsimple.refreshToken());
-  console.log(wealthsimple);
-  return wealthsimple;
+});
+
+console.log('Chances are Wealthsimple.auth is null:', badWealthsimple.auth);
+console.log('Chances are Wealthsimple.authPromise is pending:', badWealthsimple.authPromise);
+
+badWealthsimple.get('/oauth/token/info').then(() => {
+  console.log('This should never run');
+}).catch((error) => {
+  console.log('Wealthsimple.authPromise is resolved by now', badWealthsimple.authPromise);
+  console.log('Wealthsimple.auth is set by now (should be null)', badWealthsimple.auth);
+  console.log('Error is available:', error);
 });

--- a/src/index.js
+++ b/src/index.js
@@ -65,9 +65,12 @@ class Wealthsimple {
     // does not have to be prompted to log in again:
     this.auth = auth;
     if (authAccessToken && typeof authAccessToken === 'string') {
-      this.authPromise = this.accessTokenInfo(authAccessToken).then((auth) => this.auth = auth);
+      this.authPromise = this.accessTokenInfo(authAccessToken).then((a) => {
+        this.auth = a;
+        return this.auth;
+      });
     } else {
-      this.authPromise = new Promise((resolve) => resolve(this.auth));
+      this.authPromise = new Promise(resolve => resolve(this.auth));
     }
   }
 
@@ -77,10 +80,10 @@ class Wealthsimple {
       headers: { Authorization: `Bearer ${accessToken}` },
       ignoreAuthPromise: true,
       checkAuthRefresh: false,
-    }).then((response) => {
+    }).then(response =>
       // the info endpoint nests auth in a `token` root key
-      return response.json.token;
-    }).catch((error) => {
+      response.json.token,
+    ).catch((error) => {
       if (error.response.status === 401) {
         if (this.onAuthInvalid) {
           this.onAuthInvalid(error.response.json);

--- a/src/index.js
+++ b/src/index.js
@@ -75,9 +75,9 @@ class Wealthsimple {
   }
 
   // TODO: Should this have the side-effect of updating this.auth?
-  accessTokenInfo(accessToken) {
+  accessTokenInfo(accessToken = null) {
     return this.get('/oauth/token/info', {
-      headers: { Authorization: `Bearer ${accessToken}` },
+      headers: { Authorization: `Bearer ${accessToken || this.accessToken()}` },
       ignoreAuthPromise: true,
       checkAuthRefresh: false,
     }).then(response =>


### PR DESCRIPTION
Previously v1.1.0 leaked abstraction by returning a Promise from the constructor. This is not only buggy/not allowed in Node world, but is also a bad design.

Instead, the constructor still fires a promise to load the context remotely (when an access token is provided) and any subsequent HTTP calls will wait until its resolved before continuing.

Essentially:

### Before

```js
const ws = new Wealthsimple({ authAccessToken: '...' }).then((ws) => {
  // all API code must fire in here or risk an unresolved promise
  ws.get('/users').then((data) => {

  });
});
```

### After

```js
const ws = new Wealthsimple({ authAccessToken: '...' });
ws.get('/users').then((data) => {
  // `data` is is the API response. By the time this promise fires, the constructor's auth lookup promise has already resolved.
})'
```