### PR TITLE
Always send same-origin cookies, optionally allow WS-Device-ID to be set

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthsimple/wealthsimple",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "A JavaScript client for the Wealthsimple API",
   "license": "MIT",
   "main": "dist/wealthsimple.min.js",

--- a/src/api-request.js
+++ b/src/api-request.js
@@ -84,7 +84,7 @@ class ApiRequest {
   }
 
   _defaultHeaders() {
-    let h = {
+    const h = {
       Accept: 'application/json',
       'Content-Type': 'application/json',
       Date: new Date().toUTCString(),

--- a/src/api-request.js
+++ b/src/api-request.js
@@ -41,6 +41,7 @@ class ApiRequest {
       headers: newHeaders,
       method,
       body: newBody,
+      credentials: 'same-origin',
     }).then(this._handleResponse.bind(this));
   }
 
@@ -83,12 +84,16 @@ class ApiRequest {
   }
 
   _defaultHeaders() {
-    return {
+    let h = {
       Accept: 'application/json',
       'Content-Type': 'application/json',
       Date: new Date().toUTCString(),
       'X-Wealthsimple-Client': 'wealthsimple.js',
     };
+    if (this.client.deviceId) {
+      h['X-WS-Device-ID'] = this.client.deviceId;
+    }
+    return h;
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,10 @@ const constants = require('./constants');
 
 class Wealthsimple {
   constructor({
-    clientId, clientSecret, fetchAdapter, auth = null, authAccessToken = null, env = null, baseUrl = null, apiVersion = 'v1', onAuthSuccess = null, onAuthRevoke = null, onAuthInvalid = null, onResponse = null, verbose = false,
+    clientId, clientSecret, fetchAdapter, auth = null, authAccessToken = null,
+    env = null, baseUrl = null, apiVersion = 'v1', onAuthSuccess = null,
+    onAuthRevoke = null, onAuthInvalid = null, onResponse = null,
+    verbose = false, deviceId = null
   }) {
     // OAuth client details:
     if (!clientId || typeof clientId !== 'string') {
@@ -35,6 +38,8 @@ class Wealthsimple {
       throw new Error(`Unrecognized 'apiVersion'. Please use one of: ${constants.API_VERSIONS.join(', ')}`);
     }
     this.apiVersion = apiVersion;
+
+    this.deviceId = deviceId;
 
     // Optionally allow a custom request adapter to be specified (e.g. for
     // react-native) which must implement the `fetch` interface:

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ class Wealthsimple {
     clientId, clientSecret, fetchAdapter, auth = null, authAccessToken = null,
     env = null, baseUrl = null, apiVersion = 'v1', onAuthSuccess = null,
     onAuthRevoke = null, onAuthInvalid = null, onResponse = null,
-    verbose = false, deviceId = null
+    verbose = false, deviceId = null,
   }) {
     // OAuth client details:
     if (!clientId || typeof clientId !== 'string') {


### PR DESCRIPTION
This is useful for Wealthsimple's device detection and logging setup.