### PR TITLE
Send client ID and secret in token revocation call

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -200,7 +200,11 @@ class Wealthsimple {
   revokeAuth() {
     return this.authPromise.then(() => {
       if (this.auth) {
-        return this.post('/oauth/revoke')
+        const body = {
+          client_id: this.clientId,
+          client_secret: this.clientSecret,
+        };
+        return this.post('/oauth/revoke', { body })
           .then(() => {
             this.auth = null;
 


### PR DESCRIPTION
This is required by spec. Just sending the access token is insufficient