### PR TITLE
Store and expect simple-oauth2 objects in auth object

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,9 @@ const wealthsimple = new Wealthsimple({
   // Optional: Depending on grant_type may or may not be needed:
   clientSecret: '<oauth_client_secret>',
 
-  // Optional: If available, you can optionally specify a previous auth
-  // response's access token so that the user does not have to login again:
-  authAccessToken: '<your_current_access_token>',
-
-  // (Deprecated) Optional: If available, you can optionally specify a previous
-  // auth response so that the user does not have to login again:
-  auth: { ... previous auth response ... },
+  // the auth's AccessToken object from a previous session or its token object
+  // so the user does not have to login again:
+  auth: { ... previous auth object or its token object ... },
 });
 
 wealthsimple.get('/healthcheck')
@@ -70,16 +66,16 @@ authPromise
 Loading previously saved token for authenicated requests:
 
 ```js
-const accessTokenCookie = document.cookie
+const accessTokenCookie = JSON.parse(document.cookie
   .split(';')
   .map((e) => e.split('='))
-  .find((e) =>  e[0] == '_accessToken' )[1];
+  .find((e) =>  e[0] == '_oauth2access' )[1]);
 
 // Constructor async bootsraps auth context
 const wealthsimple = new Wealthsimple({
   env: 'sandbox',
   clientId: '<oauth_client_id>',
-  authAccessToken: accessTokenCookie,
+  auth: accessTokenCookie,
 });
 
 // Will wait until auth context is loaded

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthsimple/wealthsimple",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "description": "A JavaScript client for the Wealthsimple API",
   "license": "MIT",
   "main": "dist/wealthsimple.min.js",
@@ -24,7 +24,8 @@
     "isomorphic-fetch": "^2.2.1",
     "lodash.mapkeys": "^4.6.0",
     "lodash.snakecase": "^4.1.1",
-    "query-string": "^5.1.0"
+    "query-string": "^5.1.0",
+    "simple-oauth2": "^2.2.0"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",

--- a/samples/callbacks.js
+++ b/samples/callbacks.js
@@ -4,7 +4,7 @@ const Wealthsimple = require('../src/index');
 const wealthsimple = new Wealthsimple({
   env: 'sandbox',
   clientId: '58a99e4862a1b246a7745523ca230e61dd7feff351056fcb22c73a5d7a2fcd69',
-  onAuthSuccess: (data) => { console.log('success!', data); },
+  onAuthSuccess: (authTokenObject) => { console.log('success!', authTokenObject); },
   onAuthRevoke: () => { console.log('revoked!'); },
   onAuthInvalid: () => { console.log('invalid/unauthorized!'); },
 });

--- a/samples/existing_auth.js
+++ b/samples/existing_auth.js
@@ -22,18 +22,18 @@ const authPromise = previousWealthsimple.authenticate({
   password: process.env.PASSWORD,
 });
 
-let existingAccessToken;
+let existingAuth;
 
 authPromise
-  .then(() => { existingAccessToken = previousWealthsimple.accessToken(); })
+  .then(() => { existingAuth = previousWealthsimple.auth; })
   .catch(error => console.error('Error:', error))
   .then(() => {
     const wealthsimple = new Wealthsimple({
       env: 'sandbox',
       clientId: '58a99e4862a1b246a7745523ca230e61dd7feff351056fcb22c73a5d7a2fcd69',
-      authAccessToken: existingAccessToken,
+      auth: existingAuth,
     });
-    console.log(existingAccessToken);
+    console.log(existingAuth);
     console.log('Chances are Wealthsimple.auth is null:', wealthsimple.auth);
     console.log('Chances are Wealthsimple.authPromise is pending:', wealthsimple.authPromise);
     wealthsimple.get('/users').then(() => {
@@ -47,7 +47,7 @@ authPromise
 const badWealthsimple = new Wealthsimple({
   env: 'sandbox',
   clientId: '58a99e4862a1b246a7745523ca230e61dd7feff351056fcb22c73a5d7a2fcd69',
-  authAccessToken: 'd7feff351056fcb22c73a5d7a2fcd6958a99e4862a1b246a7745523ca230e61d',
+  auth: { access_token: 'd7feff351056fcb22c73a5d7a2fcd6958a99e4862a1b246a7745523ca230e61d' },
 });
 
 console.log('Chances are Wealthsimple.auth is null:', badWealthsimple.auth);

--- a/samples/refresh.js
+++ b/samples/refresh.js
@@ -18,7 +18,7 @@ authPromise
   .then(() => {
     // Pretend that it expired by setting it to a date from long ago:
     console.log('Existing Token:', wealthsimple.accessToken());
-    wealthsimple.auth.expired = function() { return true; };
+    wealthsimple.auth.expired = function () { return true; };
   })
   .then(() => wealthsimple.get(`/users/${wealthsimple.resourceOwnerId()}`))
   .then(response => console.log('Success: ', response.json, 'New Token:', wealthsimple.accessToken()))

--- a/samples/refresh.js
+++ b/samples/refresh.js
@@ -17,8 +17,9 @@ const authPromise = wealthsimple.authenticate({
 authPromise
   .then(() => {
     // Pretend that it expired by setting it to a date from long ago:
-    wealthsimple.auth.created_at = 1519775956;
+    console.log('Existing Token:', wealthsimple.accessToken());
+    wealthsimple.auth.expired = function() { return true; };
   })
   .then(() => wealthsimple.get(`/users/${wealthsimple.resourceOwnerId()}`))
-  .then(response => console.log('Success: ', response.json))
+  .then(response => console.log('Success: ', response.json, 'New Token:', wealthsimple.accessToken()))
   .catch(error => console.error('Error:', error));

--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,7 @@ class Wealthsimple {
       options: {
         bodyFormat: 'json',
         authorizationMethod: 'body',
-      }
+      },
     };
     if (this.clientSecret) {
       credentials.client.secret = this.clientSecret;
@@ -102,10 +102,10 @@ class Wealthsimple {
     // Optionally pass in existing OAuth details (access_token + refresh_token)
     // so that the user does not have to be prompted to log in again:
     if (auth) {
-      auth = (auth.constructor.name === 'AccessToken') ? auth : this.oauth2.accessToken.create(auth);
+      const a = (auth.constructor.name === 'AccessToken') ? auth : this.oauth2.accessToken.create(auth);
       // Checks auth validity on bootstrap
       this.authPromise = this.accessTokenInfo(auth.token.access_token).then(() => {
-        this.auth = auth;
+        this.auth = a;
       });
     } else {
       this.authPromise = new Promise(resolve => resolve(this.auth));
@@ -116,7 +116,7 @@ class Wealthsimple {
   accessTokenInfo(accessToken = null) {
     const token = accessToken || this.accessToken();
     if (!token) {
-      return new Promise(resolve => {
+      return new Promise((resolve) => {
         if (this.onAuthInvalid) {
           this.onAuthInvalid({});
         }
@@ -163,7 +163,14 @@ class Wealthsimple {
   }
 
   isAuthExpired() {
-    return this.auth && this.auth.expired();
+    if (this.auth) {
+      return this.auth.expired();
+    }
+    return false;
+  }
+
+  authExpiresAt() {
+    return this.auth && this.auth.token.expires_at;
   }
 
   isAuthRefreshable() {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -9,14 +9,14 @@ describe('Wealthsimple', () => {
   describe('isAuthExpired()', () => {
     describe('auth is present and not expired', () => {
       it('returns false', () => {
-        wealthsimple.auth = { expires_in: 7200, created_at: new Date() / 1000 };
+        wealthsimple.auth = wealthsimple.oauth2.accessToken.create({ expires_in: 7200, created_at: new Date() / 1000 });
         expect(wealthsimple.isAuthExpired()).toBe(false);
       });
     });
 
     describe('auth is present but expired', () => {
       it('returns true', () => {
-        wealthsimple.auth = { expires_in: 7200, created_at: new Date(2017, 4, 1) / 1000 };
+        wealthsimple.auth = wealthsimple.oauth2.accessToken.create({ expires_in: -1, created_at: new Date(2017, 4, 1) / 1000 });
         expect(wealthsimple.isAuthExpired()).toBe(true);
       });
     });
@@ -31,14 +31,14 @@ describe('Wealthsimple', () => {
   describe('isAuthRefreshable()', () => {
     describe('auth is present and refreshable', () => {
       it('returns true', () => {
-        wealthsimple.auth = { refresh_token: 'refresh' };
+        wealthsimple.auth = wealthsimple.oauth2.accessToken.create({ refresh_token: 'refresh' });
         expect(wealthsimple.isAuthRefreshable()).toBe(true);
       });
     });
 
     describe('auth is present but not refreshable', () => {
       it('returns false', () => {
-        wealthsimple.auth = { refresh_token: null };
+        wealthsimple.auth = wealthsimple.oauth2.accessToken.create({ refresh_token: null });
         expect(wealthsimple.isAuthRefreshable()).toBe(false);
       });
     });
@@ -52,9 +52,9 @@ describe('Wealthsimple', () => {
 
   describe('authExpiresAt()', () => {
     describe('auth is present', () => {
-      it('returns false', () => {
-        wealthsimple.auth = { expires_in: 7200, created_at: Date.parse('2018-02-01T04:20:12Z') / 1000 };
-        expect(wealthsimple.authExpiresAt()).toEqual(new Date(Date.parse('2018-02-01T06:20:12Z')));
+      it('returns date', () => {
+        wealthsimple.auth = wealthsimple.oauth2.accessToken.create({ expires_in: 7200, created_at: Date.parse('2018-02-01T04:20:12Z') / 1000 });
+        expect(wealthsimple.authExpiresAt()).toEqual(expect.any(Date));
       });
     });
 
@@ -79,10 +79,10 @@ describe('Wealthsimple', () => {
 
     describe('auth is present', () => {
       beforeEach(() => {
-        wealthsimple.auth = {
+        wealthsimple.auth = wealthsimple.oauth2.accessToken.create({
           resource_owner_id: 'user-abc123',
           client_canonical_id: 'person-def345',
-        };
+        });
       });
 
       it('returns the IDs', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1094,6 +1094,12 @@ boom@5.x.x:
   dependencies:
     hoek "4.x.x"
 
+boom@7.x.x:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/boom/-/boom-7.2.0.tgz#2bff24a55565767fde869ec808317eb10c48e966"
+  dependencies:
+    hoek "5.x.x"
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -1735,7 +1741,7 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-date-fns@^1.27.2:
+date-fns@^1.27.2, date-fns@^1.3.0:
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.29.0.tgz#12e609cdcb935127311d04d33334e2960a2a54e6"
 
@@ -2975,6 +2981,10 @@ hoek@4.x.x:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
 
+hoek@5.x.x:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/hoek/-/hoek-5.0.3.tgz#b71d40d943d0a95da01956b547f83c4a5b4a34ac"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -3420,6 +3430,12 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
+isemail@3.x.x:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/isemail/-/isemail-3.1.3.tgz#64f37fc113579ea12523165c3ebe3a71a56ce571"
+  dependencies:
+    punycode "2.x.x"
+
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
@@ -3803,6 +3819,14 @@ jest@^22.4.2:
   dependencies:
     import-local "^1.0.0"
     jest-cli "^22.4.2"
+
+joi@^13.0.2:
+  version "13.4.0"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-13.4.0.tgz#afc359ee3d8bc5f9b9ba6cdc31b46d44af14cecc"
+  dependencies:
+    hoek "5.x.x"
+    isemail "3.x.x"
+    topo "3.x.x"
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
@@ -5041,6 +5065,10 @@ punycode@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
 
+punycode@2.x.x:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+
 punycode@^1.2.4, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -5688,6 +5716,15 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
+simple-oauth2@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/simple-oauth2/-/simple-oauth2-2.2.0.tgz#a89f9dfe6bff37ea444a802585d6663f3560680c"
+  dependencies:
+    date-fns "^1.3.0"
+    debug "^3.1.0"
+    joi "^13.0.2"
+    wreck "^14.0.2"
+
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
@@ -6145,6 +6182,12 @@ to-regex@^3.0.1:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
+topo@3.x.x:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/topo/-/topo-3.0.0.tgz#37e48c330efeac784538e0acd3e62ca5e231fe7a"
+  dependencies:
+    hoek "5.x.x"
+
 tough-cookie@>=2.3.3, tough-cookie@^2.3.3, tough-cookie@~2.3.0, tough-cookie@~2.3.3:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.4.tgz#ec60cee38ac675063ffc97a5c18970578ee83655"
@@ -6594,6 +6637,13 @@ wrap-ansi@^2.0.0:
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+
+wreck@^14.0.2:
+  version "14.0.2"
+  resolved "https://registry.yarnpkg.com/wreck/-/wreck-14.0.2.tgz#89c17a9061c745ed1c3aebcb66ea181dbaab454c"
+  dependencies:
+    boom "7.x.x"
+    hoek "5.x.x"
 
 write-file-atomic@^1.2.0:
   version "1.3.4"


### PR DESCRIPTION
We no longer rely on the info endpoint to update the auth object, just simply run the revoked callback if not valid.

Because of our custom headers and use of fetch, we wont use simple-oauth2's HTTP calls, but take advantage of its access token object and helpers.

This makes the client handle refresh tokens appropriately :)