### PR TITLE
Remove misleading comment

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -109,7 +109,6 @@ class Wealthsimple {
       ignoreAuthPromise: true,
       checkAuthRefresh: false,
     }).then(response =>
-      // the info endpoint nests auth in a `token` root key
       response.json,
     ).catch((error) => {
       if (!error.response) {


### PR DESCRIPTION
This comment isn't quite untrue, but I don't think it's relevant here. In the older code it was more helpful, as we were dereferencing the token part just here.

They diverged in https://github.com/wealthsimple/wealthsimple.js/pull/49, when we moved the '.token' part to the code using the response.