### PR TITLE
fix: use arrayFormat: 'comma'

### DIFF
--- a/src/api-request.js
+++ b/src/api-request.js
@@ -15,7 +15,7 @@ class ApiRequest {
     let newBody = body;
 
     if (query && Object.keys(query).length > 0) {
-      newPath += `?${queryString.stringify(query, {arrayFormat: 'bracket'})}`;
+      newPath += `?${queryString.stringify(query, { arrayFormat: 'comma' })}`;
     }
     const url = this.urlFor(newPath);
 

--- a/src/api-request.js
+++ b/src/api-request.js
@@ -15,7 +15,7 @@ class ApiRequest {
     let newBody = body;
 
     if (query && Object.keys(query).length > 0) {
-      newPath += `?${queryString.stringify(query)}`;
+      newPath += `?${queryString.stringify(query, {arrayFormat: 'bracket'})}`;
     }
     const url = this.urlFor(newPath);
 


### PR DESCRIPTION
Common backend frameworks (like Rails) take only the last param when multiple params with the same name are provided. Therefore sending an array query param like `foo: ['bar', 'baz']` results in `foo=bar&foo=baz` but Rails will see only `foo=baz`. This PR changes the query param to be sent as `foo=bar,baz` which backend frameworks can then process as needed`