### PR TITLE
Patch mixin-deep vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,9 @@
     "webpack-bundle-analyzer": "^2.11.1",
     "webpack-cli": "^2.0.12"
   },
+  "resolutions": {
+    "mixin-deep": "^1.3.2"
+  },
   "jest": {
     "collectCoverageFrom": [
       "**/src/**/*.js"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5161,10 +5161,10 @@ mississippi@^2.0.0:
     stream-each "^1.1.0"
     through2 "^2.0.0"
 
-mixin-deep@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe"
-  integrity sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==
+mixin-deep@^1.2.0, mixin-deep@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"
+  integrity sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==
   dependencies:
     for-in "^1.0.2"
     is-extendable "^1.0.1"


### PR DESCRIPTION
## Why
This has affected a number of repos w/ retire.js blocking PRs, so we're getting ahead of it

## What Changed
* Manual override of the indirect dependency via resolutions