### PR TITLE
EDGE-384 Use the client machine time to calculate auth token expiry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthsimple/wealthsimple",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "A JavaScript client for the Wealthsimple API",
   "license": "MIT",
   "main": "dist/wealthsimple.min.js",

--- a/src/index.js
+++ b/src/index.js
@@ -187,16 +187,16 @@ class Wealthsimple {
       client_secret: this.clientSecret,
     };
 
+    // Set a token expiry marker using client machine local time before we fetch the token
+    const currentTime = new Date().getTime();
+
     return this.post('/oauth/token', { headers, body, checkAuthRefresh })
       .then((response) => {
         // Save auth details for use in subsequent requests:
         this.auth = response.json;
 
         // calculate a hard expiry date for proper refresh logic across reload
-        this.auth.expires_at = addSeconds(
-          this.auth.created_at * 1000, // JS operates in milliseconds
-          this.auth.expires_in,
-        );
+        this.auth.expires_at = addSeconds(currentTime, this.auth.expires_in);
 
         if (this.onAuthSuccess) {
           this.onAuthSuccess(this.auth);


### PR DESCRIPTION
#### Why?
Clients change their device time occasionally, leading to constant login/logout loops. 

#### What?
This is due to this JS client setting expiry as `server created_at time + expiry seconds` and compared against the local machine. Using the client machine time allows the comparison to be consistent based on the clients machine time.