### PR TITLE
Create index.d.ts

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,4 @@
+declare module '@wealthsimple/wealthsimple/src' {
+  const Wealthsimple: any;
+  export = Wealthsimple;
+}


### PR DESCRIPTION
This is so HWS can consume it without error. However it just exports an `any` type.

Once we have ported things to typescript we can look to improve this if needed.