### PR TITLE
Fix for auth issue on users that have the wrong time set

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthsimple/wealthsimple",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "A JavaScript client for the Wealthsimple API",
   "license": "MIT",
   "main": "dist/wealthsimple.min.js",

--- a/src/index.js
+++ b/src/index.js
@@ -270,7 +270,7 @@ class Wealthsimple {
     checkAuthRefresh = true,
   }) {
     const executePrimaryRequest = () => {
-      if (!this.isAuthExpired() && !headers.Authorization && this.accessToken()) {
+      if (!headers.Authorization && this.accessToken()) {
         headers.Authorization = `Bearer ${this.accessToken()}`;
       }
       return this.request.fetch({


### PR DESCRIPTION
There was an intermittent issue where users wouldn't be able login to their Trade desktop. The issue seems to be due to users who have the wrong time set on their computer - This library would calculate their token as expired and then refresh the token, but when setting the token on making the request, it would check again if it was expired. This would result in the token not being set because their computer still thinks the token is expired.

This fix removes that check when making the request.