### PR TITLE
[CXE-874] preferred otp device authentication params

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -4,4 +4,6 @@ module.exports = {
   OTP_HEADER: 'x-wealthsimple-otp',
   OTP_CLAIM_HEADER: 'x-wealthsimple-otp-claim',
   OKTA_CLAIM_HEADER: 'x-wealthsimple-okta-claim',
+  OTP_PREFERRED_DEVICE_TYPE: 'x-wealthsimple-otp-preferred-device-type',
+  OTP_PREFERRED_DEVICE_IDENTIFIER: 'x-wealthsimple-otp-preferred-device-identifier'
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -5,5 +5,5 @@ module.exports = {
   OTP_CLAIM_HEADER: 'x-wealthsimple-otp-claim',
   OKTA_CLAIM_HEADER: 'x-wealthsimple-okta-claim',
   OTP_PREFERRED_DEVICE_TYPE: 'x-wealthsimple-otp-preferred-device-type',
-  OTP_PREFERRED_DEVICE_IDENTIFIER: 'x-wealthsimple-otp-preferred-device-identifier'
+  OTP_PREFERRED_DEVICE_IDENTIFIER: 'x-wealthsimple-otp-preferred-device-identifier',
 };

--- a/src/index.js
+++ b/src/index.js
@@ -180,6 +180,16 @@ class Wealthsimple {
       delete attributes.oktaClaim;
     }
 
+    if (attributes.otpPreferredDeviceType) {
+      headers[constants.OTP_PREFERRED_DEVICE_TYPE] = attributes.otpPreferredDeviceType;
+      delete attributes.otpPreferredDeviceType;
+    }
+
+    if (attributes.otpPreferredDeviceIdentifier) {
+      headers[constants.OTP_PREFERRED_DEVICE_IDENTIFIER] = attributes.otpPreferredDeviceIdentifier;
+      delete attributes.otpPreferredDeviceIdentifier;
+    }
+
     let checkAuthRefresh = true;
     if (attributes.hasOwnProperty('checkAuthRefresh')) {
       ({ checkAuthRefresh } = attributes);


### PR DESCRIPTION
https://wealthsimple.atlassian.net/browse/CXE-874

We've got two new headers that we've added to the public API:

https://github.com/wealthsimple/ws-auth/blob/d22e488d87e091331ec449753bc4567c6a037c71/lib/ws/auth.rb#L43

`X-Wealthsimple-OTP-Preferred-Device-Type` and `X-Wealthsimple-OTP-Preferred-Device-Identifier`.

these are optional parameters to be sent along with token creation requests.

