### PR TITLE
Don't call token info for client-credentials calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthsimple/wealthsimple",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "A JavaScript client for the Wealthsimple API",
   "license": "MIT",
   "main": "dist/wealthsimple.min.js",

--- a/src/index.js
+++ b/src/index.js
@@ -229,6 +229,11 @@ class Wealthsimple {
       delete attributes.otp;
     }
 
+    if (attributes.otpAuthenticatedClaim) {
+      headers[constants.OTP_AUTHENTICATED_CLAIM_HEADER] = attributes.otpAuthenticatedClaim;
+      delete attributes.otpAuthenticatedClaim;
+    }
+
     if (attributes.otpClaim) {
       headers[constants.OTP_CLAIM_HEADER] = attributes.otpClaim;
       delete attributes.otpClaim;
@@ -272,9 +277,13 @@ class Wealthsimple {
           this.auth.expires_in,
         );
 
-        return response.json.accessToken;
+        return response.json.access_token;
       })
-      .then(accessToken => this.accessTokenInfo(accessToken, false))
+      .then((accessToken) => {
+        if (attributes.grant_type !== 'client_credentials') {
+          this.accessTokenInfo(accessToken, false);
+        }
+      })
       .then(() => {
         if (this.onAuthSuccess) {
           this.onAuthSuccess(this.auth);


### PR DESCRIPTION
For client-credentials call, we don't need to call `token/info` (it was causing integrationPolicy violation errors), since we don't need a clientCanonicalId or resourceOwnerId as there is none attached.

Additionally, i'm adding back a header pass through for the `OTP_AUTHENTICATED_CLAIM_HEADER` that i noticed got wiped out at some point in the previous branch