### PR TITLE
Add optional callback for token info call

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthsimple/wealthsimple",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "A JavaScript client for the Wealthsimple API",
   "license": "MIT",
   "main": "dist/wealthsimple.min.js",

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ class Wealthsimple {
     baseUrl = null,
     apiVersion = 'v1',
     onAuthSuccess = null,
+    onTokenInfoSuccess = null,
     onAuthRevoke = null,
     onAuthInvalid = null,
     onResponse = null,
@@ -78,6 +79,7 @@ class Wealthsimple {
     this.onAuthRevoke = onAuthRevoke;
     this.onAuthInvalid = onAuthInvalid;
     this.onResponse = onResponse;
+    this.onTokenInfoSuccess = onTokenInfoSuccess;
 
     this.request = new ApiRequest({ client: this });
 
@@ -118,7 +120,15 @@ class Wealthsimple {
       this.auth.client_canonical_ids = response.json.client_canonical_ids;
 
       return response.json;
-    }).catch((error) => {
+    })
+    .then((response) => {
+      if (this.onTokenInfoSuccess) {
+        this.onTokenInfoSuccess(this.auth);
+      }
+  
+      return response;
+    })
+    .catch((error) => {
       if (!error.response) {
         throw error;
       }

--- a/src/index.js
+++ b/src/index.js
@@ -120,15 +120,13 @@ class Wealthsimple {
       this.auth.client_canonical_ids = response.json.client_canonical_ids;
 
       return response.json;
-    })
-    .then((response) => {
+    }).then((response) => {
       if (this.onTokenInfoSuccess) {
         this.onTokenInfoSuccess(this.auth);
       }
-  
+
       return response;
-    })
-    .catch((error) => {
+    }).catch((error) => {
       if (!error.response) {
         throw error;
       }


### PR DESCRIPTION
### Why
This allows Terminal to set a callback that updates the auth cookies after a successful token info call

### What
- added optional callback for successful token info call